### PR TITLE
Update role to Microgrid Controls @ Intersect and add ParentWise to musings

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1039,6 +1039,18 @@ section {
     color: var(--text-muted);
 }
 
+.terminal-mini .terminal-link {
+    color: var(--accent-cyan);
+    text-decoration: none;
+    word-break: break-all;
+    transition: color 0.2s, text-shadow 0.2s;
+}
+
+.terminal-mini .terminal-link:hover {
+    text-decoration: underline;
+    text-shadow: 0 0 8px rgba(0, 212, 255, 0.4);
+}
+
 .cursor-blink {
     color: var(--accent-green);
     animation: blink 1s step-end infinite;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Engineered by Breaden</title>
     <meta name="description" content="Craig Breaden - Power Systems &amp; Controls Engineer. Microgrid control, real-time simulation, and software development for the grid edge.">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="css/styles.css?v=4">
+    <link rel="stylesheet" href="css/styles.css?v=5">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
@@ -511,6 +511,11 @@
                         <span class="terminal-title">musings.sh</span>
                     </div>
                     <div class="terminal-body">
+                        <p><span class="prompt">$</span> cat latest-project.txt</p>
+                        <p class="muted"># Latest project:</p>
+                        <p>ParentWise AI &mdash; a calmer, smarter co-pilot for parents.</p>
+                        <p><span class="prompt">$</span> open <a href="https://apps.apple.com/us/app/parentwise-ai/id6759508051" target="_blank" rel="noopener" class="terminal-link">https://apps.apple.com/us/app/parentwise-ai/id6759508051</a></p>
+                        <p class="muted"># Now on the App Store.</p>
                         <p><span class="prompt">$</span> ls -la ./posts/</p>
                         <p class="muted">total 0</p>
                         <p class="muted">drwxr-xr-x  2 craig  staff  64 Feb 18 2026 .</p>
@@ -551,6 +556,6 @@
         </div>
     </footer>
 
-    <script src="js/main.js?v=4"></script>
+    <script src="js/main.js?v=5"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -117,7 +117,7 @@
       { type: 'output', text: 'Craig Breaden', className: 'name' },
       { type: 'blank' },
       { type: 'command', text: 'cat role.txt' },
-      { type: 'output', text: 'Head of Engineering @ DaisyChain Energy' },
+      { type: 'output', text: 'Microgrid Controls @ Intersect' },
       { type: 'output', text: 'New York, NY' },
       { type: 'blank' },
       { type: 'command', text: 'cat mission.txt' },


### PR DESCRIPTION
## Summary
Two content updates to the personal site:

1. **Role update** — The `cat role.txt` line in the hero terminal animation now reads **Microgrid Controls @ Intersect** (was *Head of Engineering @ DaisyChain Energy*).
2. **Latest project in musings** — Added a block at the top of the `musings.sh` terminal highlighting **ParentWise AI**, with a clickable link to the [App Store](https://apps.apple.com/us/app/parentwise-ai/id6759508051), styled in the site's cyan accent with a glow-on-hover.

## Changes
- `js/main.js` — updated role text
- `index.html` — added latest-project block to the musings terminal; bumped asset cache-busting versions (`?v=4` → `?v=5`)
- `css/styles.css` — added `.terminal-link` styling

## Notes
- The ParentWise tagline (*"a calmer, smarter co-pilot for parents"*) is placeholder copy — easy to swap for the real description.

https://claude.ai/code/session_01Hk4HsxPCuHYzKicUuSjUv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk4HsxPCuHYzKicUuSjUv3)_