### PR TITLE
Move ParentWise into a dedicated projects section and remove musings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ tree
 - **Skills explorer** -- Six categories of things I actually work with in critical infrastructure environments. Click around, hover for context.
 - **Curiosity constellation** -- Hobby interests orbiting a center of gravity called "curiosity." Quantum computing and philosophy live here. They get along surprisingly well.
 - **Life.log** -- Running, cycling, reading, and dog metrics. All enthusiasm bars are suspiciously high.
-- **Musings placeholder** -- `ls ./posts/` returns empty. For now.
+- **Projects** -- Things I've built and shipped, like ParentWise AI on the App Store.
 
 ## Tech Stack
 
@@ -62,7 +62,6 @@ Push to `master`. GitHub Actions copies everything to `gh-pages`. That's it. The
 
 ## What's Next
 
-- [ ] Actually write blog posts for the musings section
 - [ ] Strava / Goodreads integrations
 - [ ] Dark mode toggle (it's already dark... darker mode?)
 - [ ] More interactive visualizations for the interests section

--- a/css/styles.css
+++ b/css/styles.css
@@ -635,6 +635,151 @@ section {
     transform: translateY(0);
 }
 
+/* --- Projects Section --- */
+.projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 24px;
+    max-width: 720px;
+}
+
+.project-card {
+    position: relative;
+    display: flex;
+    gap: 22px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 28px;
+    transition: all 0.3s;
+    overflow: hidden;
+}
+
+.project-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 3px;
+    height: 100%;
+    background: linear-gradient(180deg, var(--accent-cyan), var(--accent-green));
+    opacity: 0.7;
+}
+
+.project-card:hover {
+    border-color: var(--accent-cyan);
+    transform: translateY(-4px);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+}
+
+.project-icon {
+    flex-shrink: 0;
+    width: 60px;
+    height: 60px;
+    border-radius: 14px;
+    background: linear-gradient(135deg, var(--bg-secondary), var(--bg-card-hover));
+    border: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.project-icon svg {
+    width: 30px;
+    height: 30px;
+    color: var(--accent-cyan);
+}
+
+.project-info {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+}
+
+.project-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.project-title {
+    font-family: var(--font-mono);
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.project-status {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--accent-green);
+    padding: 3px 9px;
+    background: rgba(16, 185, 129, 0.12);
+    border: 1px solid rgba(16, 185, 129, 0.3);
+    border-radius: 999px;
+}
+
+.project-tagline {
+    color: var(--text-muted);
+    line-height: 1.5;
+}
+
+.project-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 2px 0 6px;
+}
+
+.project-tag {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--accent-cyan);
+    padding: 3px 10px;
+    background: rgba(0, 212, 255, 0.1);
+    border-radius: 4px;
+}
+
+.appstore-link {
+    display: inline-flex;
+    align-items: center;
+    align-self: flex-start;
+    gap: 9px;
+    font-family: var(--font-mono);
+    font-size: 0.92rem;
+    color: var(--accent-cyan) !important;
+    padding: 10px 18px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    transition: all 0.25s;
+}
+
+.appstore-link svg {
+    width: 17px;
+    height: 17px;
+}
+
+.appstore-link .arrow-icon {
+    width: 15px;
+    height: 15px;
+    transition: transform 0.25s;
+}
+
+.appstore-link:hover {
+    border-color: var(--accent-cyan);
+    background: rgba(0, 212, 255, 0.08);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(0, 212, 255, 0.15);
+}
+
+.appstore-link:hover .arrow-icon {
+    transform: translate(2px, -2px);
+}
+
 /* --- Interests Section --- */
 .interests-universe {
     display: flex;
@@ -1039,18 +1184,6 @@ section {
     color: var(--text-muted);
 }
 
-.terminal-mini .terminal-link {
-    color: var(--accent-cyan);
-    text-decoration: none;
-    word-break: break-all;
-    transition: color 0.2s, text-shadow 0.2s;
-}
-
-.terminal-mini .terminal-link:hover {
-    text-decoration: underline;
-    text-shadow: 0 0 8px rgba(0, 212, 255, 0.4);
-}
-
 .cursor-blink {
     color: var(--accent-green);
     animation: blink 1s step-end infinite;
@@ -1188,9 +1321,18 @@ section {
     .reading-grid {
         grid-template-columns: 1fr;
     }
+
+    .projects-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 @media (max-width: 640px) {
+    .project-card {
+        flex-direction: column;
+        gap: 16px;
+    }
+
     :root {
         --section-padding: 48px;
     }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1151,44 +1151,6 @@ section {
     transform: translate(2px, -2px);
 }
 
-/* --- Musings Section --- */
-.musings-placeholder {
-    max-width: 600px;
-}
-
-.terminal-mini {
-    background: rgba(17, 24, 39, 0.9);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    overflow: hidden;
-}
-
-.terminal-mini .terminal-body {
-    padding: 24px 28px;
-    font-family: var(--font-mono);
-    font-size: 1.05rem;
-    line-height: 2;
-}
-
-.terminal-mini .terminal-body p {
-    margin-bottom: 0;
-}
-
-.terminal-mini .prompt {
-    color: var(--accent-green);
-    margin-right: 8px;
-    user-select: none;
-}
-
-.terminal-mini .muted {
-    color: var(--text-muted);
-}
-
-.cursor-blink {
-    color: var(--accent-green);
-    animation: blink 1s step-end infinite;
-}
-
 /* --- Footer --- */
 #footer {
     position: relative;

--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
                 <li><a href="#interests">interests</a></li>
                 <li><a href="#life">life</a></li>
                 <li><a href="#reading">reading</a></li>
-                <li><a href="#musings">musings</a></li>
             </ul>
         </div>
     </nav>
@@ -523,42 +522,6 @@
                     <span>See more on Goodreads</span>
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="arrow-icon"><path d="M7 17l9.2-9.2M17 17V7H7"/></svg>
                 </a>
-            </div>
-        </div>
-    </section>
-
-    <!-- Musings / Blog Section -->
-    <section id="musings">
-        <div class="section-container">
-            <h2 class="section-heading"><span class="heading-accent">#</span> musings</h2>
-            <p class="section-subtitle">Not an expert in most of these -- just learning out loud. Corrections and conversations welcome.</p>
-
-            <div class="musings-placeholder">
-                <div class="terminal-mini">
-                    <div class="terminal-bar">
-                        <div class="terminal-dots">
-                            <span class="dot red"></span>
-                            <span class="dot yellow"></span>
-                            <span class="dot green"></span>
-                        </div>
-                        <span class="terminal-title">musings.sh</span>
-                    </div>
-                    <div class="terminal-body">
-                        <p><span class="prompt">$</span> ls -la ./posts/</p>
-                        <p class="muted">total 0</p>
-                        <p class="muted">drwxr-xr-x  2 craig  staff  64 Feb 18 2026 .</p>
-                        <p><span class="prompt">$</span> echo "Coming soon..."</p>
-                        <p>Coming soon...</p>
-                        <p><span class="prompt">$</span> cat topics.txt</p>
-                        <p class="muted"># Things I'm learning about:</p>
-                        <p class="muted">- Microgrid control and the grid edge</p>
-                        <p class="muted">- Energy markets &amp; policy</p>
-                        <p class="muted">- AI, optimization &amp; control</p>
-                        <p class="muted">- Hardware-in-the-loop war stories</p>
-                        <p class="muted">- Curiosity-driven explorations</p>
-                        <p><span class="prompt">$</span> <span class="cursor-blink">_</span></p>
-                    </div>
-                </div>
             </div>
         </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
             <ul class="nav-links">
                 <li><a href="#about">about</a></li>
                 <li><a href="#skills">skills</a></li>
+                <li><a href="#projects">projects</a></li>
                 <li><a href="#interests">interests</a></li>
                 <li><a href="#life">life</a></li>
                 <li><a href="#reading">reading</a></li>
@@ -286,6 +287,38 @@
         </div>
     </section>
 
+    <!-- Projects Section -->
+    <section id="projects">
+        <div class="section-container">
+            <h2 class="section-heading"><span class="heading-accent">#</span> projects</h2>
+            <p class="section-subtitle">Things I've built and shipped. More on the way.</p>
+
+            <div class="projects-grid">
+                <div class="project-card">
+                    <div class="project-icon">
+                        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.53 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
+                    </div>
+                    <div class="project-info">
+                        <div class="project-header">
+                            <h3 class="project-title">ParentWise AI</h3>
+                            <span class="project-status">Live</span>
+                        </div>
+                        <p class="project-tagline">A calmer, smarter co-pilot for parents.</p>
+                        <div class="project-tags">
+                            <span class="project-tag">iOS</span>
+                            <span class="project-tag">AI</span>
+                        </div>
+                        <a href="https://apps.apple.com/us/app/parentwise-ai/id6759508051" target="_blank" rel="noopener" class="appstore-link">
+                            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.53 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
+                            <span>Download on the App Store</span>
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="arrow-icon"><path d="M7 17l9.2-9.2M17 17V7H7"/></svg>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Interests Section -->
     <section id="interests">
         <div class="section-container">
@@ -511,11 +544,6 @@
                         <span class="terminal-title">musings.sh</span>
                     </div>
                     <div class="terminal-body">
-                        <p><span class="prompt">$</span> cat latest-project.txt</p>
-                        <p class="muted"># Latest project:</p>
-                        <p>ParentWise AI &mdash; a calmer, smarter co-pilot for parents.</p>
-                        <p><span class="prompt">$</span> open <a href="https://apps.apple.com/us/app/parentwise-ai/id6759508051" target="_blank" rel="noopener" class="terminal-link">https://apps.apple.com/us/app/parentwise-ai/id6759508051</a></p>
-                        <p class="muted"># Now on the App Store.</p>
                         <p><span class="prompt">$</span> ls -la ./posts/</p>
                         <p class="muted">total 0</p>
                         <p class="muted">drwxr-xr-x  2 craig  staff  64 Feb 18 2026 .</p>

--- a/js/main.js
+++ b/js/main.js
@@ -385,8 +385,7 @@
         '.project-card, ' +
         '.orbit-system, ' +
         '.life-card, ' +
-        '.book-card, .reading-footer, ' +
-        '.musings-placeholder'
+        '.book-card, .reading-footer'
     );
     targets.forEach((el) => el.classList.add('fade-in'));
   }

--- a/js/main.js
+++ b/js/main.js
@@ -382,6 +382,7 @@
     const targets = document.querySelectorAll(
       '.about-grid, .about-image-wrapper, .about-text, ' +
         '.skills-categories, .skills-display, ' +
+        '.project-card, ' +
         '.orbit-system, ' +
         '.life-card, ' +
         '.book-card, .reading-footer, ' +


### PR DESCRIPTION
Follow-up to #4 (which merged only the role update + ParentWise-in-musings). These are the two remaining commits from that session.

## Summary
1. **Dedicated projects section** — Moves ParentWise AI out of the musings terminal into its own `projects` section (with a nav link), placed after `skills` in the professional cluster. It's a project card with an Apple icon, a green "Live" status pill, tagline, `iOS`/`AI` tags, and a "Download on the App Store" button. Matches the existing card styling and is responsive; the grid uses `auto-fit` so future projects flow in automatically.
2. **Remove musings** — Drops the musings nav link, section markup, and musings-only CSS (`.musings-placeholder`, `.terminal-mini`, `.cursor-blink`). Shared terminal classes and the `blink` keyframe are kept for the hero terminal. README updated to match.

Net effect on the live site: ParentWise lives only in the new projects section, and musings is gone. Section order becomes **about · skills · projects · interests · life · reading**.

## Changes
- `index.html` — remove ParentWise-in-musings block; add projects section + nav link; remove musings section + nav link
- `css/styles.css` — add projects section styles (with responsive rules); remove musings-only styles
- `js/main.js` — add `.project-card` to the scroll-reveal list; remove `.musings-placeholder`
- `README.md` — swap the musings feature/TODO for projects

## Notes
- The ParentWise tagline (*"A calmer, smarter co-pilot for parents."*) is still placeholder copy.
- The project card uses the generic Apple logo as its icon — happy to swap in the real ParentWise app icon if you add it to `images/`.

https://claude.ai/code/session_01Hk4HsxPCuHYzKicUuSjUv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk4HsxPCuHYzKicUuSjUv3)_