### PR TITLE
Fix projects card styling and move section to the end

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -674,20 +674,18 @@ section {
 
 .project-icon {
     flex-shrink: 0;
-    width: 60px;
-    height: 60px;
+    width: 56px;
+    height: 56px;
     border-radius: 14px;
-    background: linear-gradient(135deg, var(--bg-secondary), var(--bg-card-hover));
-    border: 1px solid var(--border);
+    background: linear-gradient(135deg, var(--accent-cyan), var(--accent-green));
     display: flex;
     align-items: center;
     justify-content: center;
-}
-
-.project-icon svg {
-    width: 30px;
-    height: 30px;
-    color: var(--accent-cyan);
+    font-family: var(--font-mono);
+    font-weight: 700;
+    font-size: 1.25rem;
+    letter-spacing: 0.02em;
+    color: var(--bg-primary);
 }
 
 .project-info {
@@ -763,21 +761,11 @@ section {
     height: 17px;
 }
 
-.appstore-link .arrow-icon {
-    width: 15px;
-    height: 15px;
-    transition: transform 0.25s;
-}
-
 .appstore-link:hover {
     border-color: var(--accent-cyan);
     background: rgba(0, 212, 255, 0.08);
     transform: translateY(-2px);
     box-shadow: 0 4px 15px rgba(0, 212, 255, 0.15);
-}
-
-.appstore-link:hover .arrow-icon {
-    transform: translate(2px, -2px);
 }
 
 /* --- Interests Section --- */

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Engineered by Breaden</title>
     <meta name="description" content="Craig Breaden - Power Systems &amp; Controls Engineer. Microgrid control, real-time simulation, and software development for the grid edge.">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="css/styles.css?v=5">
+    <link rel="stylesheet" href="css/styles.css?v=6">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
@@ -25,10 +25,10 @@
             <ul class="nav-links">
                 <li><a href="#about">about</a></li>
                 <li><a href="#skills">skills</a></li>
-                <li><a href="#projects">projects</a></li>
                 <li><a href="#interests">interests</a></li>
                 <li><a href="#life">life</a></li>
                 <li><a href="#reading">reading</a></li>
+                <li><a href="#projects">projects</a></li>
             </ul>
         </div>
     </nav>
@@ -286,38 +286,6 @@
         </div>
     </section>
 
-    <!-- Projects Section -->
-    <section id="projects">
-        <div class="section-container">
-            <h2 class="section-heading"><span class="heading-accent">#</span> projects</h2>
-            <p class="section-subtitle">Things I've built and shipped. More on the way.</p>
-
-            <div class="projects-grid">
-                <div class="project-card">
-                    <div class="project-icon">
-                        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.53 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
-                    </div>
-                    <div class="project-info">
-                        <div class="project-header">
-                            <h3 class="project-title">ParentWise AI</h3>
-                            <span class="project-status">Live</span>
-                        </div>
-                        <p class="project-tagline">A calmer, smarter co-pilot for parents.</p>
-                        <div class="project-tags">
-                            <span class="project-tag">iOS</span>
-                            <span class="project-tag">AI</span>
-                        </div>
-                        <a href="https://apps.apple.com/us/app/parentwise-ai/id6759508051" target="_blank" rel="noopener" class="appstore-link">
-                            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.53 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
-                            <span>Download on the App Store</span>
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="arrow-icon"><path d="M7 17l9.2-9.2M17 17V7H7"/></svg>
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
     <!-- Interests Section -->
     <section id="interests">
         <div class="section-container">
@@ -526,6 +494,35 @@
         </div>
     </section>
 
+    <!-- Projects Section -->
+    <section id="projects">
+        <div class="section-container">
+            <h2 class="section-heading"><span class="heading-accent">#</span> projects</h2>
+            <p class="section-subtitle">Things I've built and shipped. More on the way.</p>
+
+            <div class="projects-grid">
+                <div class="project-card">
+                    <div class="project-icon">PW</div>
+                    <div class="project-info">
+                        <div class="project-header">
+                            <h3 class="project-title">ParentWise AI</h3>
+                            <span class="project-status">Live</span>
+                        </div>
+                        <p class="project-tagline">A calmer, smarter co-pilot for parents.</p>
+                        <div class="project-tags">
+                            <span class="project-tag">iOS</span>
+                            <span class="project-tag">AI</span>
+                        </div>
+                        <a href="https://apps.apple.com/us/app/parentwise-ai/id6759508051" target="_blank" rel="noopener" class="appstore-link">
+                            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.53 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
+                            <span>Download on the App Store</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Footer -->
     <footer id="footer">
         <div class="footer-inner">
@@ -547,6 +544,6 @@
         </div>
     </footer>
 
-    <script src="js/main.js?v=5"></script>
+    <script src="js/main.js?v=6"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes the broken-looking projects card from #5 and relocates the section.

## What was wrong
- **Huge icons** — the real cause was caching. #4 shipped `styles.css?v=5`; #5 changed the CSS contents but kept the same `?v=5` URL, so any browser that had already cached v=5 served the old stylesheet *without* the project styles. With no `width/height` on the SVGs, they rendered at full size.
- **"2 apples and an arrow"** — the card had a large Apple as its app-icon placeholder **and** an Apple inside the App Store button, plus a trailing arrow — visually redundant and confusing.

## Fixes
1. **Cache bust** — bump `styles.css` and `main.js` to `?v=6` so the project styles actually load.
2. **Cleaner card** — replace the oversized Apple app-icon with a **"PW"** gradient monogram tile (bounded size, no SVG that can blow up), and remove the redundant second Apple + the arrow from the button. The card is now: PW tile · title · "Live" pill · tagline · tags · single "Download on the App Store" button.
3. **Reposition** — move the projects section to the **end** of the page (after `reading`), and move its nav link to match. Section order is now **about · skills · interests · life · reading · projects**.

## Notes
- The "PW" monogram is a stand-in — if you add the real ParentWise app icon to `images/`, I can swap it into the tile for a sharper look.
- Tagline (*"A calmer, smarter co-pilot for parents."*) is still placeholder copy.

https://claude.ai/code/session_01Hk4HsxPCuHYzKicUuSjUv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk4HsxPCuHYzKicUuSjUv3)_